### PR TITLE
Integrate home manager

### DIFF
--- a/home-manager/flake.nix
+++ b/home-manager/flake.nix
@@ -1,0 +1,16 @@
+{
+  description = "User configurations for nonchris";
+
+  outputs = { self, nixpkgs }: {
+
+    nixosModules = {
+
+      # Desktop configuration, includes GUI
+      desktop = { imports = [ ./home.nix ]; };
+
+      # Serevr user configuration, only CLI
+      server = { imports = [ ./home-server.nix ]; };
+
+    };
+  };
+}

--- a/home-manager/home-server.nix
+++ b/home-manager/home-server.nix
@@ -1,0 +1,35 @@
+{ config, pkgs, ... }:
+
+{
+  # Let Home Manager install and manage itself.
+  programs.home-manager.enable = true;
+
+  # Home Manager needs a bit of information about you and the
+  # paths it should manage.
+  home.username = "chris";
+  home.homeDirectory = "/home/chris";
+
+  # Allow "unfree" licenced packages
+  nixpkgs.config = { allowUnfree = true; };
+
+  # Install these packages for my user
+  home.packages = with pkgs; [
+    htop
+    iperf3
+    nmap
+    unzip
+  ];
+
+  # Imports
+  imports = [ ./modules/git.nix ./modules/zsh.nix ];
+
+  # This value determines the Home Manager release that your
+  # configuration is compatible with. This helps avoid breakage
+  # when a new Home Manager release introduces backwards
+  # incompatible changes.
+  #
+  # You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version
+  # changes in each release.
+  home.stateVersion = "21.05";
+}

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -1,0 +1,70 @@
+{ config, pkgs, ... }:
+
+let
+  mayniklas = builtins.fetchGit {
+    # Updated 2020-03-07
+    url = "https://github.com/mayniklas/nixos-home";
+    rev = "cb1517d09b0995d4c7bad8424e7baa56b68c31c4";
+  };
+in {
+  # Let Home Manager install and manage itself.
+  programs.home-manager.enable = true;
+
+  # Home Manager needs a bit of information about you and the
+  # paths it should manage.
+  home.username = "chris";
+  home.homeDirectory = "/home/chris";
+
+  # Allow "unfree" licenced packages
+  nixpkgs.config = { allowUnfree = true; };
+
+  # Imports
+  imports = [
+    # imports from MayNiklas
+    "${mayniklas}/modules/chromium.nix"
+    
+    # imports
+    ./modules/alacritty.nix
+    ./modules/firefox.nix
+    ./modules/git.nix
+    ./modules/jetbrains.nix
+    ./modules/vscode.nix
+    ./modules/zsh.nix
+  ];
+
+  home.packages = with pkgs; [
+    _1password-gui
+    atom
+    discord
+    gcc
+    htop
+    hugo
+    mpv
+    nvtop
+    obs-studio
+    pstree
+    python3
+    ruby
+    signal-desktop
+    spotify
+    sublime-merge
+    sublime3
+    tdesktop
+    thunderbird
+    unzip
+    vim
+    vlc
+    whois
+    youtube-dl
+  ];
+
+  # This value determines the Home Manager release that your
+  # configuration is compatible with. This helps avoid breakage
+  # when a new Home Manager release introduces backwards
+  # incompatible changes.
+  #
+  # You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version
+  # changes in each release.
+  home.stateVersion = "21.05";
+}

--- a/home-manager/modules/alacritty.nix
+++ b/home-manager/modules/alacritty.nix
@@ -1,0 +1,56 @@
+{ config, pkgs, lib, ... }:
+let vars = import ./vars.nix;
+in {
+  # Alacritty
+  programs.alacritty = {
+    enable = true;
+    settings = {
+
+      scrolling.history = 10000;
+      env.TERM = "xterm-256color";
+
+      background_opacity = 0.9;
+      window = {
+        dimensions = {
+          lines = 45;
+          columns = 120;
+        };
+        padding = {
+          x = 3;
+          y = 3;
+        };
+      };
+      cursor = { style = "Beam"; };
+      colors = {
+        primary = {
+          background = "0x${vars.colors.base00}";
+          foreground = "0x${vars.colors.base05}";
+        };
+        cursor = {
+          text = "0x${vars.colors.base00}";
+          cursor = "0x${vars.colors.base0D}";
+        };
+        normal = {
+          black = "0x${vars.colors.base00}";
+          red = "0x${vars.colors.base08}";
+          green = "0x${vars.colors.base0B}";
+          yellow = "0x${vars.colors.base0A}";
+          blue = "0x${vars.colors.base0D}";
+          magenta = "0x${vars.colors.base0E}";
+          cyan = "0x${vars.colors.base0C}";
+          white = "0x${vars.colors.base05}";
+        };
+        bright = {
+          black = "0x${vars.colors.base03}";
+          red = "0x${vars.colors.base09}";
+          green = "0x${vars.colors.base01}";
+          yellow = "0x${vars.colors.base02}";
+          blue = "0x${vars.colors.base04}";
+          magenta = "0x${vars.colors.base06}";
+          cyan = "0x${vars.colors.base0F}";
+          white = "0x${vars.colors.base07}";
+        };
+      };
+    };
+  };
+}

--- a/home-manager/modules/firefox.nix
+++ b/home-manager/modules/firefox.nix
@@ -1,0 +1,15 @@
+{ config, pkgs, lib, ... }: {
+  programs.firefox = {
+    enable = true;
+    package = pkgs.firefox-bin;
+    profiles = {
+      chris = {
+        isDefault = true;
+        settings = {
+          "browser.startup.homepage" = "https://github.com/MayNiklas";
+          "devtools.theme" = "dark";
+        };
+      };
+    };
+  };
+}

--- a/home-manager/modules/git.nix
+++ b/home-manager/modules/git.nix
@@ -1,0 +1,14 @@
+{ config, pkgs, lib, ... }: {
+  programs = {
+    git = {
+      enable = true;
+
+      ignores = [ "tags" "*.swp" ];
+
+      extraConfig = { pull.rebase = false; };
+
+      userEmail = "git@chris-ge.de";
+      userName = "nonchris";
+    };
+  };
+}

--- a/home-manager/modules/jetbrains.nix
+++ b/home-manager/modules/jetbrains.nix
@@ -1,0 +1,10 @@
+{ config, pkgs, ... }:
+{
+  home.packages = with pkgs.jetbrains; [
+    jdk
+    clion
+    ruby-mine
+    idea-ultimate
+    pycharm-professional
+  ];
+}

--- a/home-manager/modules/vars.nix
+++ b/home-manager/modules/vars.nix
@@ -1,0 +1,97 @@
+{
+  colors = {
+
+    scheme = "generated";
+    author = "Pablo";
+
+    # base00 = "0b0b14"; # #0b0b14 color0
+    # base01 = "13131a"; # #13131a color1
+    # base02 = "262631"; # #262631 color2
+    # base03 = "3a3a47"; # #3a3a47 color3
+    # base04 = "69697c"; # #69697c color4
+    # base05 = "babac8"; # #babac8 color5
+    # base06 = "cfcfdd"; # #cfcfdd color6
+    # base07 = "ffffff"; # #ffffff color7
+    # base08 = "ff4040"; # #ff4040 color8
+    # base09 = "ff9326"; # #ff9326 color9
+    # base0A = "ffcb65"; # #ffcb65 color10
+    # base0B = "9ceb4f"; # #9ceb4f color11
+    # base0C = "18ffe0"; # #18ffe0 color12
+    # base0D = "31baff"; # #31baff color13
+    # base0E = "9d8cff"; # #9d8cff color14
+    # base0F = "3f3866"; # #3f3866 color15
+
+    # # base00 = "212733"; #212733
+    # base00 = "202734"; #202734
+    # base01 = "242B38"; #242B38
+    # base02 = "343F4C"; #343F4C
+    # base03 = "3D4751"; #3D4751
+    # base04 = "607080"; #607080
+    # base05 = "D9D7CE"; #D9D7CE
+    # base06 = "FFFFFF"; #FFFFFF
+    # base07 = "5C6773"; #5C6773
+    # base08 = "F07178"; #F07178
+    # base09 = "FF3333"; #FF3333
+    # base0A = "FFCC66"; #FFCC66
+    # base0B = "BBE67E"; #BBE67E
+    # base0C = "95E6CB"; #95E6CB
+    # base0D = "5CCFE6"; #5CCFE6
+    # base0E = "D4BFFF"; #D4BFFF
+    # base0F = "FFC44C"; #FFC44C
+
+    # scheme: "Material"
+    # author: "Nate Peterson"
+    # base00 = "263238"; # #263238
+    # base01 = "2E3C43"; # #2E3C43
+    # base02 = "314549"; # #314549
+    # base03 = "546E7A"; # #546E7A
+    # base04 = "B2CCD6"; # #B2CCD6
+    # base05 = "F3F5F7"; # #F3F5F7
+    # base06 = "EEFFFF"; # #EEFFFF
+    # base07 = "FFFFFF"; # #FFFFFF
+    base08 = "F07178"; # #F07178
+    base09 = "F78C6C"; # #F78C6C
+    base0A = "ffee6b"; # yellow
+    base0B = "C3E88D"; # #C3E88D
+    base0C = "89DDFF"; # #89DDFF
+    base0D = "caff70"; # lime green
+    base0E = "d48df0"; # pinkish
+    base0F = "FF5370"; # #FF5370
+
+# scheme: "Nord"
+# author: "arcticicestudio"
+base00 = "292929"; # #grey
+base01 = "3B4252"; # #3B4252
+base02 = "434C5E"; # #434C5E
+base03 = "4C566A"; # #4C566A
+base04 = "D8DEE9"; # #D8DEE9
+base05 = "E5E9F0"; # #E5E9F0
+base06 = "ECEFF4"; # #ECEFF4
+base07 = "8FBCBB"; # #8FBCBB
+# base08 = "BF616A"; # #BF616A
+# base09 = "D08770"; # #D08770
+# base0A = "EBCB8B"; # #EBCB8B
+# base0B = "A3BE8C"; # #A3BE8C
+# base0C = "88C0D0"; # #88C0D0
+# base0D = "81A1C1"; # #81A1C1
+# base0E = "B48EAD"; # #B48EAD
+# base0F = "5E81AC"; # #5E81AC
+
+  };
+
+  font = {
+    normal = {
+      family = "Sauce Code Pro Nerd Font";
+      style = "Semibold";
+    };
+    bold = {
+      family = "Sauce Code Pro Nerd Font";
+      style = "Bold";
+    };
+    italic = {
+      family = "Sauce Code Pro Nerd Font";
+      style = "Semibold Italic";
+    };
+    size = 10;
+  };
+}

--- a/home-manager/modules/vscode.nix
+++ b/home-manager/modules/vscode.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, lib, ... }: {
+
+  programs.vscode = {
+    enable = true;
+    package = pkgs.vscode;
+    extensions = with pkgs.vscode-extensions; [
+      ms-python.python
+      ms-vscode.cpptools
+      vscodevim.vim
+    ];
+  };
+}

--- a/home-manager/modules/zsh.nix
+++ b/home-manager/modules/zsh.nix
@@ -1,0 +1,41 @@
+{ config, pkgs, lib, ... }: {
+
+  programs.zsh = {
+    enable = true;
+    enableAutosuggestions = true;
+    enableCompletion = true;
+    autocd = true;
+    dotDir = ".config/zsh";
+
+    sessionVariables = { ZDOTDIR = "/home/chris/.config/zsh"; };
+
+    initExtra = ''
+      bindkey "^[[1;5C" forward-word
+      bindkey "^[[1;5D" backward-word
+    '';
+
+    history = {
+      expireDuplicatesFirst = true;
+      ignoreSpace = false;
+      save = 15000;
+      share = true;
+    };
+
+    plugins = [
+      {
+        name = "fast-syntax-highlighting";
+        file = "fast-syntax-highlighting.plugin.zsh";
+        src = "${pkgs.zsh-fast-syntax-highlighting}/share/zsh/site-functions";
+      }
+      {
+        name = "zsh-nix-shell";
+        file = "nix-shell.plugin.zsh";
+        src = "${pkgs.zsh-nix-shell}/share/zsh-nix-shell";
+      }
+    ];
+  };
+  programs.dircolors = {
+    enable = true;
+    enableZshIntegration = true;
+  };
+}

--- a/machines/desktop/configuration.nix
+++ b/machines/desktop/configuration.nix
@@ -9,6 +9,10 @@ let
     url = "https://github.com/mayniklas/nixos";
     rev = "bc05167e9221088531f1b03978bd4fdb8a86cbee";
   };
+  home-manager = builtins.fetchGit {
+    url = "https://github.com/nix-community/home-manager.git";
+    ref = "master";
+  };
 in {
   imports = [
     # Include the results of the hardware scan.
@@ -35,6 +39,9 @@ in {
     ../../modules/hosts
     ../../modules/networking
     ../../modules/nix-common
+
+    # home-manager
+    (import "${home-manager}/nixos")
   ];
 
   mainUser = "chris";
@@ -57,6 +64,8 @@ in {
   nonchris = {
     common.enable = true;
   };
+
+  home-manager.users.chris = { imports = [ ../../home-manager/home.nix ]; };
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/machines/flap/configuration.nix
+++ b/machines/flap/configuration.nix
@@ -9,6 +9,10 @@ let
     url = "https://github.com/mayniklas/nixos";
     rev = "bc05167e9221088531f1b03978bd4fdb8a86cbee";
   };
+  home-manager = builtins.fetchGit {
+    url = "https://github.com/nix-community/home-manager.git";
+    ref = "master";
+  };
 in {
   imports = [
     # Include the results of the hardware scan.
@@ -34,6 +38,9 @@ in {
     ../../modules/hosts
     ../../modules/networking
     ../../modules/nix-common
+
+    # home-manager
+    (import "${home-manager}/nixos")
   ];
 
   mainUser = "chris";
@@ -56,6 +63,8 @@ in {
   nonchris = {
     common.enable = true;
   };
+
+  home-manager.users.chris = { imports = [ ../../home-manager/home.nix ]; };
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions

--- a/machines/mobi/configuration.nix
+++ b/machines/mobi/configuration.nix
@@ -5,10 +5,6 @@ let
     url = "https://github.com/mayniklas/nixos";
     rev = "d4fa719e8a3b7bc7d6e2ddde7b4c84e1a011becf";
   };
-  home = builtins.fetchGit {
-    url = "https://github.com/nonchris/nixos-home";
-    ref = "main";
-  };
   home-manager = builtins.fetchGit {
     url = "https://github.com/nix-community/home-manager.git";
     ref = "master";
@@ -43,7 +39,7 @@ in {
   mainUser = "chris";
   mainUserHome = "${config.users.extraUsers.${config.mainUser}.home}";
 
-  home-manager.users.chris = import "${home}/home-server.nix";
+  home-manager.users.chris = { imports = [ ../../home-manager/home-server.nix ]; };
 
   networking = { hostName = "mobi"; };
 

--- a/machines/rick/configuration.nix
+++ b/machines/rick/configuration.nix
@@ -5,10 +5,6 @@ let
     url = "https://github.com/mayniklas/nixos";
     rev = "c0cda4acecaac8b4d335d6d82f92e7c39d3aa41b";
   };
-  home = builtins.fetchGit {
-    url = "https://github.com/nonchris/nixos-home";
-    ref = "main";
-  };
   home-manager = builtins.fetchGit {
     url = "https://github.com/nix-community/home-manager.git";
     ref = "master";
@@ -45,7 +41,7 @@ in {
   mainUser = "chris";
   mainUserHome = "${config.users.extraUsers.${config.mainUser}.home}";
 
-  home-manager.users.chris = import "${home}/home-server.nix";
+  home-manager.users.chris = { imports = [ ../../home-manager/home-server.nix ]; };
 
   networking = { hostName = "rick"; };
 


### PR DESCRIPTION
Integrale home-manager into NixOS repo.
Advantage:
- home-manager gets build/tested & cached via CI
- simplification -> only a single repository
- easier deployment onto new hosts
- easier usage of nix flakes (no flake.lock file) -> simplifies testing

Todo
- archive home-manager repo for read only access: https://github.com/nonchris/nixos-home